### PR TITLE
Fix popover being hidden by mobile keyboard

### DIFF
--- a/src/components/ScoreInput.tsx
+++ b/src/components/ScoreInput.tsx
@@ -158,7 +158,7 @@ export default function ScoreInput({
       <PopoverTrigger asChild>
         {children}
       </PopoverTrigger>
-      <PopoverContent className="w-64">
+      <PopoverContent className="w-64" side="top" align="center" sideOffset={10} avoidCollisions={true}>
         <form onSubmit={handleSubmit} className="space-y-3">
           <div className="space-y-2">
             <h4 className="font-medium text-sm">Enter score for {rowLabel} ({columnLabel})</h4>


### PR DESCRIPTION
## Summary
- Position score input popover above the cell instead of below to prevent mobile keyboard from covering it
- Add collision avoidance to ensure popover remains visible at viewport edges
- Increase spacing between popover and trigger element for better visibility

## Test plan
- [ ] Open the app on mobile device or use Chrome DevTools device emulation
- [ ] Tap on any score cell to open the input popover
- [ ] Verify popover appears above the cell
- [ ] Verify popover remains visible when keyboard appears
- [ ] Test on cells near the top edge to ensure collision avoidance works

🤖 Generated with [Claude Code](https://claude.com/claude-code)